### PR TITLE
Enable roundToIconSize property in TaskIcon.qml to make icon zoom smooth

### DIFF
--- a/plasmoid/package/contents/ui/task/TaskIcon.qml
+++ b/plasmoid/package/contents/ui/task/TaskIcon.qml
@@ -87,7 +87,7 @@ Item {
     Kirigami.Icon {
         id: taskIconItem
         anchors.fill: parent
-        //roundToIconSize: false
+        roundToIconSize: false
         source: LatteCore.Environment.iconSourceForTheme(decoration)
         visible: !badgesLoader.active
 


### PR DESCRIPTION
This was commented out in https://github.com/KDE/latte-dock/commit/08118d531c27588716d28f835cf7891782f8a439
Apparently it was not needed back then, smooth zoom just worked.
Now, Kirigami.Icon's smooth icon zoom seems to be broken. Restoring roundToIconSize: false is a stopgap solution to this.
During testing, one of the icons still had choppy zoom on occasion. But I am unable to reproduce this consistently
roundToIconSize should probably stay until a better fix is implemented.

Video of before and after:
https://github.com/user-attachments/assets/ffdb1966-6eee-449a-8563-bce933808d14

