### PR TITLE
Fix drag and drop of files onto tasks

### DIFF
--- a/plasmoid/package/contents/ui/main.qml
+++ b/plasmoid/package/contents/ui/main.qml
@@ -940,7 +940,7 @@ PlasmoidItem {
                 });
             }
 
-            function onUrlsDropped(urls) {
+            onUrlsDropped: (urls) => {
                 //! inform synced docks for new dropped launchers
                 if (onlyLaunchersInDroppedList(urls)) {
                     appletAbilities.launchers.addDroppedLaunchers(urls);

--- a/plasmoid/package/contents/ui/taskslayout/MouseHandler.qml
+++ b/plasmoid/package/contents/ui/taskslayout/MouseHandler.qml
@@ -363,7 +363,7 @@ Item {
             }
         }
 
-        function onDragEnter(event) {
+        onDragEnter: (event) => {
             inMovingTask = isMovingTask(event);
             inDroppingOnlyLaunchers = !inMovingTask && isDroppingOnlyLaunchers(event);
             inDroppingSeparator = !inMovingTask && isDroppingSeparator(event);
@@ -384,7 +384,7 @@ Item {
             dArea.containsDrag = true;
         }
 
-        function onDragMove(event) {
+        onDragMove: (event) => {
             if (!eventIsAccepted) {
                 clearDroppingFlags();
                 event.ignore();
@@ -459,7 +459,7 @@ Item {
             activationTimer.stop();
         }
 
-        function onDrop(event) {
+        onDrop: (event) => {
             if (!eventIsAccepted) {
                 clearDroppingFlags();
                 event.ignore();


### PR DESCRIPTION
In Qt6, a signal handler written as function func() is a plain method and it never connects to the signal, unless it is used in a Connections object.
The tasks DropArea's onDragEnter, onDragMove, onDrop and the MouseHandler's onUrlsDropped were all written that way and not inside any Connections object, so they never fired for external file/url drops.

Converted them to the handler-binding form and now it works.
It's probably worthwhile to check for additional occurrences of this bug elsewhere in the project.