### PR TITLE
fix: convert onDragMove to Qt6 handler-binding syntax in ToolTipDelegate2

### DIFF
--- a/plasmoid/package/contents/ui/previews/ToolTipDelegate2.qml
+++ b/plasmoid/package/contents/ui/previews/ToolTipDelegate2.qml
@@ -81,7 +81,7 @@ PlasmaComponents.ScrollView {
                 windowsPreviewDlg.hide(9.9);
             }
 
-            function onDragMove(event) {
+            onDragMove: (event) => {
                 var current = mainToolTip.instanceAtPos(event.x, event.y);
 
                 if (current && currentWindow !== current && current.submodelIndex) {


### PR DESCRIPTION
## Summary

In Qt6, `function onDragMove(event)` inside a DropArea is treated as a plain JavaScript method and **never connects to the signal**, unless it is used in a `Connections` object.

PR #19 fixed this same bug in `MouseHandler.qml` (`onDragEnter`, `onDragMove`, `onDrop`) and `main.qml` (`onUrlsDropped`), but missed one remaining instance in **`ToolTipDelegate2.qml:84`**.

## The bug

The `onDragMove` handler in the grouped task preview tooltip DropArea was written as:
```js
function onDragMove(event) {
    var current = mainToolTip.instanceAtPos(event.x, event.y);
    if (current && currentWindow !== current && current.submodelIndex) {
        currentWindow = current;
        tasksModel.requestActivate(current.submodelIndex);
    }
}
```

This never fired in Qt6, meaning hovering between window preview thumbnails within the grouped task tooltip did not switch the active window.

## Fix

Converted to the Qt6-compatible handler-binding form:
```js
onDragMove: (event) => {
    // same body
}
```

## Testing

- [x] Installed and ran locally with debug build
- [x] Zero QML errors or warnings in log
- [x] Grouped task preview hover switching works correctly
- [x] No regressions in dock behavior

## Related

- PR #19: Fix drag and drop of files onto tasks