### PR TITLE
fix: convert widget's drag-and-drop handlers to Qt6 handler-binding syntax 

### DIFF
--- a/containment/package/contents/ui/DragDropArea.qml
+++ b/containment/package/contents/ui/DragDropArea.qml
@@ -122,7 +122,7 @@ DragDrop.DropArea {
         }
     }
 
-    function onDragEnter(event) {
+    onDragEnter: (event) => {
         containsDrag = true;
         clearInfoTimer.stop();
         var isTask = isInternalTaskSource(event) || hasTaskMime(event);
@@ -170,7 +170,7 @@ DragDrop.DropArea {
         dndSpacer.opacity = 1;
     }
 
-    function onDragMove(event) {
+    onDragMove: (event) => {
         containsDrag = true;
         clearInfoTimer.stop();
         if (dragInfo.isTask) {
@@ -200,7 +200,7 @@ DragDrop.DropArea {
         dndSpacer.parent = root;
     }
 
-    function onDrop(event) {
+    onDrop: (event) => {
         containsDrag = false;
         animations.needLength.removeEvent(dragArea);
 


### PR DESCRIPTION
This change restores the ability to drag files from other apps (for instance: files and folders from dolphin) into the dock's widget area.
Same bug as in https://github.com/ruizhi-lab/latte-dock-ng/pull/19 and https://github.com/ruizhi-lab/latte-dock-ng/pull/20