### PR TITLE
fix: convert widget's drag-and-drop handlers to Qt6 handler-binding syntax

### DIFF
--- a/containment/package/contents/ui/DragDropArea.qml
+++ b/containment/package/contents/ui/DragDropArea.qml
@@ -122,7 +122,7 @@ DragDrop.DropArea {
         }
     }
 
-    function onDragEnter(event) {
+    onDragEnter: (event) => {
         containsDrag = true;
         clearInfoTimer.stop();
         var isTask = isInternalTaskSource(event) || hasTaskMime(event);
@@ -170,7 +170,7 @@ DragDrop.DropArea {
         dndSpacer.opacity = 1;
     }
 
-    function onDragMove(event) {
+    onDragMove: (event) => {
         containsDrag = true;
         clearInfoTimer.stop();
         if (dragInfo.isTask) {
@@ -200,7 +200,7 @@ DragDrop.DropArea {
         dndSpacer.parent = root;
     }
 
-    function onDrop(event) {
+    onDrop: (event) => {
         containsDrag = false;
         animations.needLength.removeEvent(dragArea);
 


### PR DESCRIPTION
Converts Qt5-style `function onDrag*(event)` to Qt6 `onDrag*: (event) =>` syntax in DragDropArea.qml.

⚠️ **Needs rework** — testing found the arrow-function syntax causes 2 widgets to be created on drop instead of 1. The original `function onDragEnter(event)` works correctly. Needs investigation into why the binding syntax causes duplicate drop handling.

Original PR: qrlh