### PR TITLE
fix: presenting a minimized group member first restores/unminimizes that member

### DIFF
--- a/plasmoid/package/contents/ui/task/SubWindows.qml
+++ b/plasmoid/package/contents/ui/task/SubWindows.qml
@@ -165,18 +165,37 @@ Item{
     //! Skip "phantom" group entries (e.g. ghostty's headless daemon
     //! registers an xdg_toplevel with no real surface; activating it is a
     //! no-op which makes the task icon feel frozen).
+    //!
+    //! IsHidden is true for "phantoms" AND for minimized windows
+    //! A real minimized window still has a WinIdList and IsMinimized === true
+    //! Only reject group entries that are hidden without being minimized
     function isActivatableChild(kid) {
         if (!kid || !kid.model) {
-            return false;
-        }
-        if (kid.model.IsHidden === true) {
             return false;
         }
         var winIdList = kid.model.WinIdList;
         if (winIdList === undefined || winIdList.length === 0) {
             return false;
         }
+        if (kid.model.IsHidden === true && kid.model.IsMinimized !== true) {
+            return false;
+        }
         return true;
+    }
+
+    //! Activate child by subIndex
+    //! Restore it first, if minimized
+    //! In plasma 6 requestActivate() does not unminimize windows by itself,
+    //! so minimized group members would be skipped if they aren't unminimized first
+    function activateChild(subIndex) {
+        var mi = tasksModel.makeModelIndex(index, subIndex);
+        var kid = windowsLocalModel.items.get(subIndex);
+
+        if (kid && kid.model.IsMinimized === true) {
+            tasksModel.requestToggleMinimized(mi);
+        }
+
+        tasksModel.requestActivate(mi);
     }
 
     //! function which is used to cycle activation into
@@ -227,7 +246,7 @@ Item{
         if (nextAvailableWindow === -1)
             nextAvailableWindow = 0;
 
-        tasksModel.requestActivate(tasksModel.makeModelIndex(index,nextAvailableWindow));
+        activateChild(nextAvailableWindow);
     }
 
     //! function which is used to cycle activation into
@@ -272,7 +291,7 @@ Item{
         if (prevAvailableWindow === -2)
             prevAvailableWindow = 0;
 
-        tasksModel.requestActivate(tasksModel.makeModelIndex(index,prevAvailableWindow));
+        activateChild(prevAvailableWindow);
     }
 
     //! function which is used to cycle activation into


### PR DESCRIPTION
### Description of the issue:
In the default plasma task manager, when the user clicks through group members and lands on a minimized group member, that group member is first restored/unminimized, so that it can be presented.
Currently in latte-dock-ng, the minimized group members are silently skipped and not presented, as `requestActivate()` does not unminimize them by itself.

### What has changed:
1. Added a helper function `activateChild()` to check if a selected group member is minimized and restore/unminimize it before passing it to `requestActivate()`.
2. Replaced usage of `tasksModel.requestActivate()` in `activateNextTask()` with `activateChild()`.
3. Group members that are hidden without being minimized will be rejected in `isActivatableChild()`, as those are likely not real windows - previously all hidden windows were rejected, including minimized ones.

### Tests performed:
- [x] Builds and installs in user mode?
- [x] Is the behavior as expected?
- [x] The log shows no related warnings or errors during testing?
- [x] Do the unit test results remain unchanged as compared to current main [456154e](https://github.com/ruizhi-lab/latte-dock-ng/commit/456154efbd91fa20c2076fcf8f31fa2ab2d2a2b1)? 