### PR TITLE
fix: background blur

### DIFF
--- a/containment/package/contents/ui/BindingsExternal.qml
+++ b/containment/package/contents/ui/BindingsExternal.qml
@@ -192,7 +192,18 @@ Item {
         target: latteView && latteView.effects ? latteView.effects : null
         property: "effectiveBackgroundOpacity"
         when: latteView && latteView.effects
-        value: plasmoid.configuration.panelTransparency === -1 ? 1.0 : background.currentOpacity
+        //! Forcing 1.0 for the default setting always causes the blur effect to be skipped.
+        //! (Values >= 0.95 are skipped in effects.cpp)
+        //! Meanwhile the panel translucency gets the theme's maxOpacity,
+        //! so report the theme's maxOpacity here as well.
+        //! This makes translucent themes able to get blur.
+        value: {
+            if (plasmoid.configuration.panelTransparency !== -1) {
+                return background.currentOpacity;
+            }
+
+            return background.themeExtendedBackground ? background.themeExtendedBackground.maxOpacity : 1.0;
+        }
     }
 
     Binding{

--- a/containment/package/contents/ui/main.qml
+++ b/containment/package/contents/ui/main.qml
@@ -37,23 +37,6 @@ ContainmentItem {
     Kirigami.Theme.inherit: false
     Kirigami.Theme.colorSet: Kirigami.Theme.Window
 
-    property real panelBgOpacity: 1.0
-    property bool panelCustomTransparency: false
-
-    Timer {
-        id: panelCfgSync
-        interval: 300
-        repeat: true
-        running: true
-        onTriggered: {
-            var pt = plasmoid.configuration.panelTransparency
-            var isDefault = (pt === -1 || pt === "-1" || pt === undefined || pt === null || pt === "" || Number(pt) >= 100)
-            root.panelBgOpacity = isDefault ? 1.0 : Number(pt) / 100.0
-            root.panelCustomTransparency = !isDefault
-        }
-    }
-
-
     LayoutMirroring.enabled: Qt.application.layoutDirection === Qt.RightToLeft && !root.isVertical
     LayoutMirroring.childrenInherit: true
 
@@ -113,7 +96,8 @@ ContainmentItem {
         return changed;
     }
 
-    property bool blurEnabled: !panelCustomTransparency && plasmoid.configuration.blurEnabled && (!forceTransparentPanel || forcePanelForBusyBackground)
+    //! Blur must not be disabled when the user picks a custom translucency value, or it will be unusable
+    property bool blurEnabled: plasmoid.configuration.blurEnabled && (!forceTransparentPanel || forcePanelForBusyBackground)
 
     readonly property bool inDraggingOverAppletOrOutOfContainment: latteView && latteView.containsDrag && !backDropArea.containsDrag
 


### PR DESCRIPTION
### Issue:
The dock's background blur would not work at all.

### What has changed:
1. Removed `!panelCustomTransparency` guard on `blurEnabled` in `/containment/package/contents/ui/main.qml`. This would always block blur from being enabled when users set a custom opacity.

2. Removed `panelCfgSync` timer in main.qml. This made a unit test fail, however nothing used `panelBgOpacity` or `panelCustomTransparency` anymore and the actual transparency path in `MyViewPrivate.qml` never touched this timer.
As is, transparency settings are reactive via kcfg and the removal of the timer does not seem to impact the functionality at all.

3. Replaced `effectiveBackgroundOpacity` value.
Previously this would always set 1.0 at default opacity (-1), which forced blur off for all themes, as `effects.cpp` only renders blur for values below 0.95.
It now attempts to set the opacity to `background.themeExtendedBackground.maxOpacity`. This is what is already used for the actual background transparency itself.

### Summary:
Changes 1. and 2. enable blur on custom opacity values.
Change 3 enables blur on default opacity, which is derived from the plasma theme.
Blur is still gated on its toggle button, so it can be enabled or disabled at will.
Translucency and blur are fully responsive to settings changes.

Note: The blur effect is not visible while the "edit dock" settings menu is open - it has to be closed for the effect to be visible.
I have thus far been unable to figure out why this is the case.

### Tests performed:

- [x] Builds and installs in user mode?
- [x] Is the behavior as expected?
- [x] The log shows no related warnings or errors during testing?

- The unit test `SourceContractTest::mainQmlPanelCfgSyncTransparencySevenInputClasses()` fails, but the associated code was unused and is unnecessary/redundant. Furthermore, it was breaking blur functionality.

Please let me know how you want to proceed with this. I recommend just removing the timer unless you have some specific reason in mind to keep it that I didn't know about.