### PR TITLE
[New Feature with a Little BUG] Changed Animation from Bounce to Bounce with Parabolic

### DIFF
--- a/plasmoid/package/contents/ui/task/TaskItem.qml
+++ b/plasmoid/package/contents/ui/task/TaskItem.qml
@@ -117,10 +117,7 @@ AbilityItem.BasicItem {
     // Keep hover wave active for neighboring tasks while dragging. Only the
     // dragged source item itself should block parabolic updates.
     parabolicItem.isParabolicEventBlocked: ((root.dragSource !== null) && (root.dragSource === taskItem))
-                                           || !hoverEnabled
                                            || !taskItem.abilities.myView.isShownFully
-                                           || inAnimation
-                                           || (inBlockingAnimation && !inAttentionBuiltinAnimation)
     parabolicItem.isUpdatingOnlySpacers: inAttentionBuiltinAnimation || inBouncingAnimation
 
     property alias hoverEnabled: taskMouseArea.hoverEnabled

--- a/plasmoid/package/contents/ui/task/TaskMouseArea.qml
+++ b/plasmoid/package/contents/ui/task/TaskMouseArea.qml
@@ -18,8 +18,9 @@ MouseArea {
     // Qt6 can let parent flickables steal mouse sequences during small motion,
     // resulting in press without release and missed task activation.
     preventStealing: true
-    hoverEnabled: taskItem.visible && (!inAnimation) && (!isStartup) && (!root.taskInAnimation)
-                  &&(!inBouncingAnimation) && !isSeparator
+
+    // prevent from freeze
+    hoverEnabled: true
 
     property bool pressed: false
     // Drag should start only after resistance delay expires and pointer

--- a/plasmoid/package/contents/ui/task/animations/LauncherAnimation.qml
+++ b/plasmoid/package/contents/ui/task/animations/LauncherAnimation.qml
@@ -63,7 +63,9 @@ Item{
     function init(){
         //console.log ("Nooo 1 : "+root.noTasksInAnimation);
         if(!launchedAlready) {
-            taskItem.abilities.parabolic.invkClearZoom();
+
+            // the taskItem.abilities.parabolic.invkClearZoom has been disabled to prevent it from recovering after clicked the icon
+
             launchedAlready = true;
             taskItem.abilities.animations.needThickness.addEvent(needThicknessEvent);
 
@@ -92,7 +94,7 @@ Item{
         }
 
         if(root.launcherBouncingEnabled) {
-            taskItem.animationStarted();
+
             init();
             launcherAnimationLoader.item.start();
         } else {

--- a/plasmoid/package/contents/ui/task/animations/launcher/BounceAnimation.qml
+++ b/plasmoid/package/contents/ui/task/animations/launcher/BounceAnimation.qml
@@ -19,39 +19,25 @@ SequentialAnimation{
         }
     }
 
-    //Ghost animation that acts as a delayer
+    //! I think the Ghost animation is useless, why don't we make other animations longer?
+    //! Here disabled ParallelAnimation to prevent the zoom recovering...
+    // make the second rise animation alone
     PropertyAnimation {
-        target: taskItem.parabolicItem
-        property: "opacity"
-        to: 1
-        duration:  50
-        easing.type: Easing.InQuad
-    }
-    //end of ghost animation
-
-    ParallelAnimation {
-        PropertyAnimation {
-            target: taskItem.parabolicItem
-            property: "zoom"
-            to: 1
-            duration: launcherAnimation.speed
-            easing.type: Easing.OutQuad
-        }
-
-        PropertyAnimation {
-            target: taskItem
-            property: bouncePropertyName
-            to: taskItem.abilities.metrics.iconSize
-            duration: launcherAnimation.speed
-            easing.type: Easing.OutQuad
-        }
+        target: taskItem
+        property: bouncePropertyName
+        to: taskItem.abilities.metrics.iconSize
+        //! make the duration a little longer to make it seems more fluent and better
+        duration: 1.5 * launcherAnimation.speed
+        easing.type: Easing.OutQuad
     }
 
+    // this is the fall animation
     PropertyAnimation {
         target: taskItem
         property: bouncePropertyName
         to: 0
-        duration: 4*launcherAnimation.speed
+        // make the duration a little longer to make it seems more fluent and better
+        duration: 5 * launcherAnimation.speed
         easing.type: Easing.OutBounce
     }
 


### PR DESCRIPTION
Based on the existing animation, I have made the following improvements:

1.    **Parallel Execution for Parabolic Animation**: When the parabolic animation is enabled, launching an app now triggers both the icon bounce and the parabolic animation simultaneously. It no longer reverts to an unscaled state. (Previously, clicking an unlaunched app icon without moving the mouse would cause the parabolic animation to fade out, followed by an icon bounce, and finally scale up from small to the parabolic state).

2.    **Adjusted Bounce Duration**: Slightly fine-tuned the icon bounce duration during startup to make the overall animation feel smoother and more natural.

**However, there is a minor bug with the concurrent animations**:
During the icon's bounce phase (from launch to touchdown), its size **does not update dynamically based on the mouse distance**, causing it to appear oversized before touchdown. Once the animation finishes, it instantly snaps back to the correct scale. (This glitch is particularly noticeable if you move the mouse to a distant icon before the bounce animation ends).

just like this:
[屏幕录像_20260730_155322.webm](https://github.com/user-attachments/assets/8debb2ce-0bd9-486a-bfa2-688e8b14e20c)

I hope we can work together to refine this.
