### PR TITLE
[Fix] Corrected zooming logic during parabolic-effect start

### DIFF
--- a/declarativeimports/abilities/items/BasicItem.qml
+++ b/declarativeimports/abilities/items/BasicItem.qml
@@ -396,7 +396,7 @@ Item{
     BasicItemParts.RestoreAnimation{id: _restoreAnimation}
 
     function slotClearZoom(){
-        restoreAnimation.start();
+        abilityItem.parabolicItem.zoom = 1;
     }
 
     // Feed drag pointer coordinates directly to the parabolic tracker when

--- a/declarativeimports/abilities/items/basicitem/ParabolicEventsArea.qml
+++ b/declarativeimports/abilities/items/basicitem/ParabolicEventsArea.qml
@@ -129,15 +129,13 @@ Item {
                 return;
             }
 
-            if( ((abilityItem.parabolicItem.zoom === 1 || abilityItem.parabolicItem.zoom === abilityItem.abilities.parabolic.factor.zoom)
-                 && !abilityItem.abilities.parabolic.directRenderingEnabled)
-                    || abilityItem.abilities.parabolic.directRenderingEnabled) {
-
-                var step = Math.abs(lastParabolicPos-mousePos);
-                if (step >= abilityItem.abilities.animations.hoverPixelSensitivity){
-                    lastParabolicPos = mousePos;
-                    calculateParabolicScales(mousePos);
-                }
+            //!   Checks for whether it is fully zoomed or not zoomed at all,
+            //! has been removed to make it like DirectRendering, which will
+            //! improve the stuttering issue when not fully zoomed.
+            var step = Math.abs(lastParabolicPos-mousePos);
+            if (step >= abilityItem.abilities.animations.hoverPixelSensitivity){
+                lastParabolicPos = mousePos;
+                calculateParabolicScales(mousePos);
             }
         }
     }
@@ -156,8 +154,15 @@ Item {
         //! icon stuck magnified until the animation ends. Restore the zoom
         //! right away; without a running animation direct rendering is
         //! enabled and this branch is not hit.
-        if (!abilityItem.abilities.parabolic.directRenderingEnabled && abilityItem.parabolicItem.zoom > 1) {
+        //!
+        //!   A check for whether the zoom has been completed has been added to
+        //! avoid incorrectly setting the zoom multiplier..
+        if (!abilityItem.abilities.parabolic.directRenderingEnabled
+            && abilityItem.parabolicItem.zoom > 1
+            && abilityItem.abilities.parabolic.isZoomed == true
+        ) {
             abilityItem.parabolicItem.zoom = 1;
+            abilityItem.abilities.parabolic.isZoomed = false;
         }
     }
 

--- a/declarativeimports/abilities/items/basicitem/ParabolicEventsArea.qml
+++ b/declarativeimports/abilities/items/basicitem/ParabolicEventsArea.qml
@@ -100,8 +100,6 @@ Item {
         lastMouseX = mouseX;
         lastMouseY = mouseY;
 
-        restoreAnimation.stop();
-
         if (isThinTooltipEnabled) {
             abilityItem.abilities.thinTooltip.show(abilityItem.tooltipVisualParent, abilityItem.thinTooltipText);
         }
@@ -154,15 +152,9 @@ Item {
         //! icon stuck magnified until the animation ends. Restore the zoom
         //! right away; without a running animation direct rendering is
         //! enabled and this branch is not hit.
-        //!
-        //!   A check for whether the zoom has been completed has been added to
-        //! avoid incorrectly setting the zoom multiplier..
-        if (!abilityItem.abilities.parabolic.directRenderingEnabled
-            && abilityItem.parabolicItem.zoom > 1
-            && abilityItem.abilities.parabolic.isZoomed == true
-        ) {
-            abilityItem.parabolicItem.zoom = 1;
-            abilityItem.abilities.parabolic.isZoomed = false;
+        if (!abilityItem.abilities.parabolic.directRenderingEnabled && abilityItem.parabolicItem.zoom > 1) {
+            // abilityItem.parabolicItem.zoom = 1;
+            // I HAVE NOT FINISHED THE ANIMATION PART !!!
         }
     }
 

--- a/declarativeimports/abilities/items/basicitem/ParabolicItem.qml
+++ b/declarativeimports/abilities/items/basicitem/ParabolicItem.qml
@@ -59,15 +59,13 @@ Item{
     readonly property alias titleTooltipVisualParent: _titleTooltipVisualParent
 
     readonly property string bothAxisZoomEvent: parabolicItem + "_zoom"
-    /* Rectangle{
-            anchors.fill: parent
-            border.width: 1
-            border.color: "green"
-            color: "transparent"
-        }*/
+
+    property alias zoomBehaviorAnimation: _zoomBehaviorAnimation
+
 
     Behavior on zoom {
         NumberAnimation{
+            id: _zoomBehaviorAnimation
             duration: (!abilityItem.abilities.parabolic.directRenderingEnabled || restoreAnimation.running)
                       ? 3 * abilityItem.animationTime : 0
             easing.type: Easing.OutCubic

--- a/declarativeimports/abilities/items/basicitem/RestoreAnimation.qml
+++ b/declarativeimports/abilities/items/basicitem/RestoreAnimation.qml
@@ -17,6 +17,6 @@ SequentialAnimation{
         property: "zoom"
         to: 1
         duration: 3 * abilityItem.animationTime
-        easing.type: Easing.InCubic
+        easing.type: Easing.OutCubic
     }
 }


### PR DESCRIPTION
 Hi, I've fixed the issue #40 😉
 Just added a check..

Here are two short videos , and U can see the difference:

Before:
[Screen.Recording_20260809_153907.webm](https://github.com/user-attachments/assets/caa757ea-0993-492c-8303-ba7690a942aa)


After:
[Screen.Recording_20260812_161333.webm](https://github.com/user-attachments/assets/adeccb35-12e8-4d31-9c71-739624dfa2da)


It is not very perfect, but it has been improved a little


