### PR TITLE
fix: restore Meta+number task shortcuts

### DIFF
--- a/app/apptypes.h
+++ b/app/apptypes.h
@@ -70,6 +70,8 @@ inline constexpr const char DESKTOPFILENAME[] = "org.kde.latte-dock";
 inline constexpr const char QMLURI[] = "latte-dock";
 inline constexpr const char PRIVATEQMLURI[] = "org.kde.latte.private.app";
 inline constexpr const char BINARYNAME[] = "latte-dock-ng";
+// Bump when a same-version package ships QML changes that invalidate disk cache.
+inline constexpr const char QMLCACHEREVISION[] = "1";
 
 inline constexpr const char WAYLANDPRIMARYAPPID[] = "latte-dock-ng";
 inline constexpr const char WAYLANDLEGACYAPPID[] = "latte-dock";

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -891,7 +891,8 @@ inline void autoClearQmlCacheOnVersionChange()
                               + QStringLiteral("/lattedock/qmlcache");
     const QString versionFilePath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation)
                                     + QStringLiteral("/lattedock/qmlcache_version");
-    const QString currentVersion = QStringLiteral(VERSION);
+    const QString currentVersion = QStringLiteral(VERSION) + QLatin1Char('-')
+                                   + QString::fromLatin1(Latte::App::QMLCACHEREVISION);
 
     QFile versionFile(versionFilePath);
     QString cachedVersion;

--- a/app/view/containmentinterface.cpp
+++ b/app/view/containmentinterface.cpp
@@ -12,6 +12,7 @@
 // local
 #include "pluginids.h"
 #include "view.h"
+#include "visualitemsearch.h"
 #include "../lattecorona.h"
 #include "../layout/genericlayout.h"
 #include "../layouts/importer.h"
@@ -261,6 +262,8 @@ ContainmentInterface::ContainmentInterface(Latte::View *parent)
 
     connect(m_view, &View::containmentChanged
     , this, [&]() {
+        clearShortcutsHost();
+
         if (m_view->containment()) {
             connect(m_view->containment(), &Plasma::Containment::appletAdded, this, &ContainmentInterface::onAppletAdded);
             m_appletsExpandedConnectionsTimer.start();
@@ -281,21 +284,42 @@ void ContainmentInterface::identifyShortcutsHost()
         return;
     }
 
-    if (QQuickItem *graphicItem = m_view->containment()->property("_plasma_graphicObject").value<QQuickItem *>()) {
-        const auto &childItems = graphicItem->childItems();
+    clearShortcutsHost();
 
-        for (QQuickItem *item : childItems) {
-            if (item->objectName() == QLatin1String("containmentViewLayout")) {
-                for (QQuickItem *subitem : item->childItems()) {
-                    if (subitem->objectName() == QLatin1String("PositionShortcutsAbilityHost")) {
-                        m_shortcutsHost = subitem;
-                        identifyMethods();
-                        return;
-                    }
-                }
-            }
-        }
+    if (!m_view || !m_view->containment()) {
+        return;
     }
+
+    QQuickItem *searchRoot{nullptr};
+
+    if (m_layoutManager) {
+        searchRoot = m_layoutManager->property("rootItem").value<QQuickItem *>();
+    }
+
+    if (!searchRoot) {
+        searchRoot = m_view->containment()->property("_plasma_graphicObject").value<QQuickItem *>();
+    }
+
+    m_shortcutsHost = findQuickItemByObjectName(searchRoot, QStringLiteral("PositionShortcutsAbilityHost"));
+
+    if (!m_shortcutsHost) {
+        return;
+    }
+
+    m_shortcutsHostDestroyedConnection = connect(
+        m_shortcutsHost, &QObject::destroyed, this, &ContainmentInterface::clearShortcutsHost);
+    identifyMethods();
+}
+
+void ContainmentInterface::clearShortcutsHost()
+{
+    disconnect(m_shortcutsHostDestroyedConnection);
+    m_shortcutsHostDestroyedConnection = {};
+    m_shortcutsHost.clear();
+    m_activateEntryMethod = QMetaMethod();
+    m_appletIdForIndexMethod = QMetaMethod();
+    m_newInstanceMethod = QMetaMethod();
+    m_showShortcutsMethod = QMetaMethod();
 }
 
 void ContainmentInterface::identifyMethods()

--- a/app/view/containmentinterface.h
+++ b/app/view/containmentinterface.h
@@ -179,6 +179,7 @@ private Q_SLOTS:
     void onPlasmaTasksCountChanged();
 
 private:
+    void clearShortcutsHost();
     void addExpandedApplet(PlasmaQuick::AppletQuickItem * appletQuickItem);
     void removeExpandedApplet(PlasmaQuick::AppletQuickItem *appletQuickItem);
     void initAppletConfigurationSignals(const int &id, QQmlPropertyMap *configuration);
@@ -208,6 +209,7 @@ private:
     QMetaMethod m_appletIdForIndexMethod;
     QMetaMethod m_newInstanceMethod;
     QMetaMethod m_showShortcutsMethod;
+    QMetaObject::Connection m_shortcutsHostDestroyedConnection;
 
     QPointer<Latte::Corona> m_corona;
     QPointer<Latte::View> m_view;

--- a/app/view/visualitemsearch.h
+++ b/app/view/visualitemsearch.h
@@ -1,0 +1,59 @@
+/*
+    SPDX-FileCopyrightText: 2026 Ruizhi Zhong <ruizhi.zhong88@gmail.com>
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef VISUALITEMSEARCH_H
+#define VISUALITEMSEARCH_H
+
+#include <QList>
+#include <QObject>
+#include <QQuickItem>
+#include <QSet>
+#include <QString>
+
+namespace Latte {
+namespace ViewPart {
+
+//! Find a QQuickItem anywhere in the QObject/QQuickItem descendant tree.
+inline QQuickItem *findQuickItemByObjectName(QObject *root, const QString &objectName)
+{
+    if (!root) {
+        return nullptr;
+    }
+
+    QList<QObject *> pending{root};
+    QSet<QObject *> visited;
+
+    while (!pending.isEmpty()) {
+        QObject *object = pending.takeLast();
+
+        if (!object || visited.contains(object)) {
+            continue;
+        }
+
+        visited.insert(object);
+        pending.append(object->children());
+
+        auto *item = qobject_cast<QQuickItem *>(object);
+
+        if (!item) {
+            continue;
+        }
+
+        if (item->objectName() == objectName) {
+            return item;
+        }
+
+        for (QQuickItem *childItem : item->childItems()) {
+            pending.append(childItem);
+        }
+    }
+
+    return nullptr;
+}
+
+}
+}
+
+#endif

--- a/autotests/sourcecontracttest.cpp
+++ b/autotests/sourcecontracttest.cpp
@@ -188,6 +188,9 @@ private Q_SLOTS:
     void uniqueNameExhaustionFallsBackToRandomSuffix();
     void layoutManagerResolveAppletQuickItemThreadsVisitedSet();
     void appdataComponentIdKeepsHyphenInLastSegment();
+    void positionShortcutHandlersDeclareSignalParameters();
+    void positionShortcutHostLookupIsRecursiveAndResettable();
+    void qmlCacheRevisionInvalidatesSameVersionBuilds();
 
     // Applet menu / popup contracts
     void needsAttentionStatusBlocksHidingWithoutWindowReconfiguration();
@@ -3723,6 +3726,54 @@ void SourceContractTest::appdataComponentIdKeepsHyphenInLastSegment()
     QVERIFY(!src.contains(QStringLiteral("<id>org.kde.latte-dock.desktop</id>")));
     QVERIFY(src.contains(QStringLiteral("<developer id=")));
     QVERIFY(!src.contains(QStringLiteral("<developer_name>")));
+}
+
+void SourceContractTest::positionShortcutHandlersDeclareSignalParameters()
+{
+    QFile basicItem(QStringLiteral(LATTE_SOURCE_DIR "/declarativeimports/abilities/items/BasicItem.qml"));
+    QVERIFY(basicItem.open(QFile::ReadOnly));
+    const QString basicSource = QString::fromUtf8(basicItem.readAll());
+    QVERIFY(basicSource.contains(QStringLiteral("function onSglActivateEntryAtIndex(entryIndex)")));
+    QVERIFY(basicSource.contains(QStringLiteral("function onSglNewInstanceForEntryAtIndex(entryIndex)")));
+    QVERIFY(!basicSource.contains(QStringLiteral("shortcutIndex(taskItem.itemIndex)")));
+
+    QFile appletItem(QStringLiteral(LATTE_SOURCE_DIR "/containment/package/contents/ui/applet/AppletItem.qml"));
+    QVERIFY(appletItem.open(QFile::ReadOnly));
+    const QString appletSource = QString::fromUtf8(appletItem.readAll());
+    QVERIFY(appletSource.contains(QStringLiteral("function onSglActivateEntryAtIndex(entryIndex)")));
+    QVERIFY(appletSource.contains(QStringLiteral("function onSglNewInstanceForEntryAtIndex(entryIndex)")));
+}
+
+void SourceContractTest::positionShortcutHostLookupIsRecursiveAndResettable()
+{
+    QFile sourceFile(QStringLiteral(LATTE_SOURCE_DIR "/app/view/containmentinterface.cpp"));
+    QVERIFY(sourceFile.open(QFile::ReadOnly));
+    const QString source = QString::fromUtf8(sourceFile.readAll());
+    QVERIFY(source.contains(QStringLiteral("findQuickItemByObjectName(searchRoot")));
+    QVERIFY(source.contains(QStringLiteral("m_layoutManager->property(\"rootItem\")")));
+    QVERIFY(source.contains(QStringLiteral("clearShortcutsHost();")));
+    QVERIFY(source.contains(QStringLiteral("m_shortcutsHostDestroyedConnection")));
+
+    QFile bridgeFile(QStringLiteral(LATTE_SOURCE_DIR "/declarativeimports/abilities/bridge/PositionShortcuts.qml"));
+    QVERIFY(bridgeFile.open(QFile::ReadOnly));
+    const QString bridgeSource = QString::fromUtf8(bridgeFile.readAll());
+    QVERIFY(bridgeSource.contains(QStringLiteral("function onSglActivateEntryAtIndex(entryIndex)")));
+    QVERIFY(bridgeSource.contains(QStringLiteral("client.sglActivateEntryAtIndex(entryIndex)")));
+    QVERIFY(!bridgeSource.contains(QStringLiteral("host.sglActivateEntryAtIndex.connect")));
+}
+
+void SourceContractTest::qmlCacheRevisionInvalidatesSameVersionBuilds()
+{
+    QFile appTypes(QStringLiteral(LATTE_SOURCE_DIR "/app/apptypes.h"));
+    QVERIFY(appTypes.open(QFile::ReadOnly));
+    const QString appTypesSource = QString::fromUtf8(appTypes.readAll());
+    QVERIFY(appTypesSource.contains(QStringLiteral("QMLCACHEREVISION[] = \"1\"")));
+
+    QFile mainSourceFile(QStringLiteral(LATTE_SOURCE_DIR "/app/main.cpp"));
+    QVERIFY(mainSourceFile.open(QFile::ReadOnly));
+    const QString mainSource = QString::fromUtf8(mainSourceFile.readAll());
+    QVERIFY(mainSource.contains(QStringLiteral("Latte::App::QMLCACHEREVISION")));
+    QVERIFY(mainSource.contains(QStringLiteral("cachedVersion != currentVersion")));
 }
 
 QTEST_MAIN(SourceContractTest)

--- a/autotests/sourcecontracttest.cpp
+++ b/autotests/sourcecontracttest.cpp
@@ -3767,8 +3767,8 @@ void SourceContractTest::qmlCacheRevisionInvalidatesSameVersionBuilds()
     QFile appTypes(QStringLiteral(LATTE_SOURCE_DIR "/app/apptypes.h"));
     QVERIFY(appTypes.open(QFile::ReadOnly));
     const QString appTypesSource = QString::fromUtf8(appTypes.readAll());
-    QVERIFY(appTypesSource.contains(QStringLiteral("QMLCACHEREVISION[] = \"1\"")));
-
+    QVERIFY(appTypesSource.contains(QStringLiteral("QMLCACHEREVISION[] = \"")));
+    QVERIFY(!appTypesSource.contains(QStringLiteral("QMLCACHEREVISION[] = \"\"")));
     QFile mainSourceFile(QStringLiteral(LATTE_SOURCE_DIR "/app/main.cpp"));
     QVERIFY(mainSourceFile.open(QFile::ReadOnly));
     const QString mainSource = QString::fromUtf8(mainSourceFile.readAll());

--- a/containment/package/contents/ui/applet/AppletItem.qml
+++ b/containment/package/contents/ui/applet/AppletItem.qml
@@ -1311,7 +1311,7 @@ Item {
     Connections{
         target: appletItem.shortcuts
 
-        function onSglActivateEntryAtIndex() {
+        function onSglActivateEntryAtIndex(entryIndex) {
             if (!appletItem.shortcuts.unifiedGlobalShortcuts) {
                 return;
             }
@@ -1323,7 +1323,7 @@ Item {
             }
         }
 
-        function onSglNewInstanceForEntryAtIndex() {
+        function onSglNewInstanceForEntryAtIndex(entryIndex) {
             if (!appletItem.shortcuts.unifiedGlobalShortcuts) {
                 return;
             }

--- a/declarativeimports/abilities/bridge/PositionShortcuts.qml
+++ b/declarativeimports/abilities/bridge/PositionShortcuts.qml
@@ -9,18 +9,8 @@ BridgeItem {
     id: shortcutsBridge
     readonly property bool isConnected: host && client
 
-    onIsConnectedChanged: {
-        if (isConnected) {
-            host.sglActivateEntryAtIndex.connect(client.sglActivateEntryAtIndex);
-            host.sglNewInstanceForEntryAtIndex.connect(client.sglNewInstanceForEntryAtIndex);
-        } else {
-            host.sglActivateEntryAtIndex.disconnect(client.sglActivateEntryAtIndex);
-            host.sglNewInstanceForEntryAtIndex.disconnect(client.sglNewInstanceForEntryAtIndex);
-        }
-    }
-
     onClientChanged: {
-        if (client) {
+        if (host && client) {
             if (host.appletIdStealingPositionShortcuts !== shortcutsBridge.appletIndex) {
                 client.disabledIsStealingGlobalPositionShortcuts();
             }
@@ -37,17 +27,22 @@ BridgeItem {
 
     Connections {
         target: host
-        function onCurrentAppletStealingPositionShortcuts() {
+        function onSglActivateEntryAtIndex(entryIndex) {
+            if (client) {
+                client.sglActivateEntryAtIndex(entryIndex);
+            }
+        }
+
+        function onSglNewInstanceForEntryAtIndex(entryIndex) {
+            if (client) {
+                client.sglNewInstanceForEntryAtIndex(entryIndex);
+            }
+        }
+
+        function onCurrentAppletStealingPositionShortcuts(id) {
             if (appletIndex !== id && client) {
                 client.disabledIsStealingGlobalPositionShortcuts();
             }
-        }
-    }
-
-    Component.onDestruction: {
-        if (isConnected) {
-            host.sglActivateEntryAtIndex.disconnect(client.sglActivateEntryAtIndex);
-            host.sglNewInstanceForEntryAtIndex.disconnect(client.sglNewInstanceForEntryAtIndex);
         }
     }
 }

--- a/declarativeimports/abilities/items/BasicItem.qml
+++ b/declarativeimports/abilities/items/BasicItem.qml
@@ -155,7 +155,7 @@ Item{
 
     Connections {
         target: abilityItem.abilities.shortcuts
-        function onSglActivateEntryAtIndex() {
+        function onSglActivateEntryAtIndex(entryIndex) {
             if (!abilityItem.abilities.shortcuts.isEnabled) {
                 return;
             }
@@ -167,12 +167,12 @@ Item{
             }
         }
 
-        function onSglNewInstanceForEntryAtIndex() {
+        function onSglNewInstanceForEntryAtIndex(entryIndex) {
             if (!abilityItem.abilities.shortcuts.isEnabled) {
                 return;
             }
 
-            var shortcutIndex = abilityItem.abilities.shortcuts.shortcutIndex(taskItem.itemIndex);
+            var shortcutIndex = abilityItem.abilities.shortcuts.shortcutIndex(abilityItem.itemIndex);
 
             if (shortcutIndex === entryIndex) {
                 abilityItem.shortcutRequestedNewInstance();


### PR DESCRIPTION
Meta+number stopped activating tasks because the shortcut delivery path had multiple breakages: the C++ side could fail to find the QML shortcut host after the UI hierarchy changed, QML handlers dropped entryIndex, and the bridge could remain connected to a destroyed client.

Restore the shortcuts with three fixes:

1. Items: declare entryIndex in the BasicItem.qml and AppletItem.qml Connections handlers, and look up the new-instance shortcut index through abilityItem.itemIndex instead of the invalid outer-scope taskItem reference.

2. Bridge: replace the manual connect()/disconnect() wiring in PositionShortcuts.qml with Connections forwarding that resolves the current client when each signal is emitted. This keeps recreated clients receiving shortcuts and also preserves the applet ID carried by the shortcut-stealing signal.

3. Host lookup: search the QObject/QQuickItem descendant graph from the layout manager root item, with the containment graphic object as a fallback, instead of assuming a fixed two-level item hierarchy. Clear the cached host and QMetaMethods when the containment changes or the host is destroyed.

Add source contract tests for the handler signatures, bridge forwarding, host lookup/reset wiring, and QML cache revision.

Bump the QML cache revision so same-version packages containing these QML changes invalidate the on-disk QML cache.