### PR TITLE
fix: make autostart opt-out and mechanism-aware

### DIFF
--- a/app/lattecorona.cpp
+++ b/app/lattecorona.cpp
@@ -1411,7 +1411,15 @@ void Corona::updateDockItemBadge(QString identifier, QString value)
 
 void Corona::setAutostart(const bool &enabled)
 {
-    m_universalSettings->setAutostart(enabled);
+    //! Persist the user's intent so the ensure-autostart logic never
+    //! recreates the entry on the next startup.
+    m_universalSettings->setEnsureAutostart(enabled);
+
+    if (!enabled) {
+        //! Explicit disable removes the XDG entry we own. Any systemd unit is
+        //! intentionally left untouched (it is not latte's to manage).
+        Layouts::Importer::disableAutostart();
+    }
 }
 
 void Corona::switchToLayout(QString layout)

--- a/app/layouts/importer.cpp
+++ b/app/layouts/importer.cpp
@@ -29,6 +29,7 @@
 #include <KArchive/KArchiveEntry>
 #include <KArchive/KArchiveDirectory>
 #include <KConfigGroup>
+#include <KDesktopFile>
 #include <KLocalizedString>
 #include <KNotification>
 
@@ -526,7 +527,16 @@ bool Importer::importHelper(QString fileName)
 bool Importer::isAutostartEnabled()
 {
     QFile autostartFile(Latte::configPath() + QLatin1String("/autostart/org.kde.latte-dock.desktop"));
-    return autostartFile.exists();
+
+    if (!autostartFile.exists()) {
+        return false;
+    }
+
+    //! Honor the XDG autostart spec: an entry with Hidden=true exists on disk
+    //! but is disabled. Treat it as "not enabled" so it is neither reported as
+    //! a conflict nor mistaken for a working autostart mechanism.
+    KDesktopFile desktopFile(autostartFile.fileName());
+    return !desktopFile.desktopGroup().readEntry(QStringLiteral("Hidden"), false);
 }
 
 void Importer::enableAutostart()
@@ -565,7 +575,13 @@ void Importer::enableAutostart()
         QFileInfo autostartInfo(autostartFile.fileName());
         QFileInfo metaInfo(metaFilePath);
 
-        if (autostartInfo.lastModified() >= metaInfo.lastModified()) {
+        //! A present-but-hidden entry is disabled per the XDG spec. Even when
+        //! it is newer than the source, re-enabling must clear Hidden=true by
+        //! replacing it with the clean shipped desktop file.
+        KDesktopFile existingEntry(autostartFile.fileName());
+        const bool hidden = existingEntry.desktopGroup().readEntry(QStringLiteral("Hidden"), false);
+
+        if (!hidden && autostartInfo.lastModified() >= metaInfo.lastModified()) {
             return;
         }
 

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -55,8 +55,10 @@
 // KDE
 #include <KLocalizedString>
 #include <KAboutData>
+#include <KConfigGroup>
 #include <KCoreAddons/KSignalHandler>
 #include <KDBusService>
+#include <KSharedConfig>
 #include <KWindowSystem>
 #include <QQmlEngine>
 #include <plasmaquick/sharedqmlengine.h>
@@ -260,12 +262,22 @@ int main(int argc, char **argv)
 
     if (parser.isSet(QStringLiteral("enable-autostart"))) {
         Latte::Layouts::Importer::enableAutostart();
+
+        //! Persist the intent so startup keeps ensuring the entry.
+        KSharedConfig::openConfig()->group(QStringLiteral("UniversalSettings")).writeEntry(QStringLiteral("ensureAutostart"), true);
+        KSharedConfig::openConfig()->sync();
+
         qGuiApp->exit();
         return 0;
     }
 
     if (parser.isSet(QStringLiteral("disable-autostart"))) {
         Latte::Layouts::Importer::disableAutostart();
+
+        //! Persist the intent so startup does not recreate the entry.
+        KSharedConfig::openConfig()->group(QStringLiteral("UniversalSettings")).writeEntry(QStringLiteral("ensureAutostart"), false);
+        KSharedConfig::openConfig()->sync();
+
         qGuiApp->exit();
         return 0;
     }

--- a/app/settings/settingsdialog/settingsdialog.ui
+++ b/app/settings/settingsdialog/settingsdialog.ui
@@ -723,10 +723,23 @@
              <item row="3" column="1">
               <widget class="QCheckBox" name="autostartChkBox">
                <property name="toolTip">
-                <string>Start the application automatically after each relogin</string>
+                <string>Make sure at least one autostart mechanism is active after each relogin. When unchecked, Latte does not touch existing autostart entries.</string>
                </property>
                <property name="text">
-                <string>Enable autostart during startup</string>
+                <string>Ensure autostart during startup</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QLabel" name="autostartWarningLbl">
+               <property name="visible">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Both a systemd service and the KDE autostart entry are enabled for Latte. This may start Latte twice at login; remove one of them to avoid it.</string>
+               </property>
+               <property name="wordWrap">
+                <bool>true</bool>
                </property>
               </widget>
              </item>

--- a/app/settings/settingsdialog/tabpreferenceshandler.cpp
+++ b/app/settings/settingsdialog/tabpreferenceshandler.cpp
@@ -77,6 +77,7 @@ void TabPreferences::initUi()
 
     connect(m_ui->autostartChkBox, &QCheckBox::toggled, this, [this]() {
         m_preferences.autostart = m_ui->autostartChkBox->isChecked();
+        updateAutostartWarning();
         Q_EMIT dataChanged();
     });
 
@@ -100,7 +101,7 @@ void TabPreferences::initUi()
 
 void TabPreferences::initSettings()
 {
-    o_preferences.autostart = m_corona->universalSettings()->autostart();
+    o_preferences.autostart = m_corona->universalSettings()->ensureAutostart();
     o_preferences.badgeStyle3D = m_corona->universalSettings()->badges3DStyle();
     o_preferences.contextMenuAlwaysActions = m_corona->universalSettings()->contextMenuActionsAlwaysShown();
     o_preferences.isAvailableGeometryBroadcastedToPlasma = m_corona->universalSettings()->isAvailableGeometryBroadcastedToPlasma();
@@ -135,6 +136,7 @@ void TabPreferences::updateUi()
 {
     //! ui load
     m_ui->autostartChkBox->setChecked(m_preferences.autostart);
+    updateAutostartWarning();
     m_ui->badges3DStyleChkBox->setChecked(m_preferences.badgeStyle3D);
     m_ui->infoWindowChkBox->setChecked(m_preferences.layoutsInformationWindow);
     m_ui->broadcastGeomChkBox->setChecked(m_preferences.isAvailableGeometryBroadcastedToPlasma);
@@ -175,6 +177,15 @@ void TabPreferences::onActionsBtnPressed()
     viewsDlg->exec();
 }
 
+void TabPreferences::updateAutostartWarning()
+{
+    //! Warn only when the user asked latte to ensure autostart and both a
+    //! systemd unit and the XDG entry are active at the same time.
+    const bool conflict = m_ui->autostartChkBox->isChecked()
+                          && m_corona->universalSettings()->autostartMechanismsConflict();
+    m_ui->autostartWarningLbl->setVisible(conflict);
+}
+
 void TabPreferences::reset()
 {
     m_preferences = o_preferences;
@@ -189,7 +200,7 @@ void TabPreferences::resetDefaults()
 
 void TabPreferences::save()
 {
-    m_corona->universalSettings()->setAutostart(m_preferences.autostart);
+    m_corona->universalSettings()->setEnsureAutostart(m_preferences.autostart);
     m_corona->universalSettings()->setBadges3DStyle(m_preferences.badgeStyle3D);
     m_corona->universalSettings()->setContextMenuActionsAlwaysShown(m_preferences.contextMenuAlwaysActions);
     m_corona->universalSettings()->setIsAvailableGeometryBroadcastedToPlasma(m_preferences.isAvailableGeometryBroadcastedToPlasma);

--- a/app/settings/settingsdialog/tabpreferenceshandler.h
+++ b/app/settings/settingsdialog/tabpreferenceshandler.h
@@ -63,6 +63,7 @@ private Q_SLOTS:
     void updateUi();
 
     void onActionsBtnPressed();
+    void updateAutostartWarning();
 
 private:
     Latte::Settings::Dialog::SettingsDialog *m_parentDialog{nullptr};

--- a/app/settings/universalsettings.cpp
+++ b/app/settings/universalsettings.cpp
@@ -22,6 +22,7 @@
 // Qt
 #include <QDebug>
 #include <QDir>
+#include <QProcess>
 
 // KDE
 #include <KActivities/Consumer>
@@ -67,21 +68,11 @@ UniversalSettings::~UniversalSettings()
 
 void UniversalSettings::load()
 {
-    //! check if user has set the autostart option
-    bool autostartUserSet = m_universalGroup.readEntry(QStringLiteral("userConfiguredAutostart"), false);
-
-    if (!autostartUserSet && !autostart()) {
-        //! the first time the application is running and autostart is not set, autostart is enabled
-        //! and from now own it will not be recreated in the beginning
-
-        setAutostart(true);
-        m_universalGroup.writeEntry(QStringLiteral("userConfiguredAutostart"), true);
-    } else if (autostartUserSet && !autostart()) {
-        //! autostart was configured before but the desktop file is missing
-        //! (removed by an uninstall, depclean or a failed update); restore it
-        //! so autostart cannot silently break on every login again.
-        qCWarning(latteApp) << "Autostart desktop file is missing while autostart is configured; recreating it.";
-        setAutostart(true);
+    //! Ensure-autostart: when enabled (default), guarantee that at least one
+    //! autostart mechanism exists; when disabled, stay silent and leave every
+    //! autostart mechanism untouched.
+    if (ensureAutostart()) {
+        ensureAutostartEntry();
     }
 
     //! init screen scales
@@ -278,6 +269,78 @@ void UniversalSettings::setAutostart(bool state)
     }
 
     Q_EMIT autostartChanged();
+}
+
+bool UniversalSettings::ensureAutostart() const
+{
+    return m_universalGroup.readEntry(QStringLiteral("ensureAutostart"), true);
+}
+
+void UniversalSettings::setEnsureAutostart(bool enabled)
+{
+    m_universalGroup.writeEntry(QStringLiteral("ensureAutostart"), enabled);
+    //! Flush immediately so an explicit CLI/DBus/UI disable survives even if
+    //! the process exits before the config is saved through the normal path.
+    m_universalGroup.sync();
+
+    if (enabled) {
+        ensureAutostartEntry();
+    }
+    //! Disabled means "don't manage": leave every existing autostart mechanism
+    //! (XDG entry or systemd unit) untouched, and stay silent.
+
+    Q_EMIT autostartChanged();
+}
+
+bool UniversalSettings::autostartMechanismsConflict() const
+{
+    return isSystemdAutostartEnabled() && Layouts::Importer::isAutostartEnabled();
+}
+
+void UniversalSettings::ensureAutostartEntry()
+{
+    const bool systemdSet = isSystemdAutostartEnabled();
+    const bool desktopSet = Layouts::Importer::isAutostartEnabled();
+
+    if (systemdSet && desktopSet) {
+        //! Both mechanisms are active; a duplicate startup attempt may occur.
+        //! Log-only: the single-instance lock already rejects the second process.
+        qCWarning(latteApp) << "Latte autostart: both a systemd user unit and the XDG autostart entry are enabled; duplicate startup may occur.";
+    } else if (!systemdSet && !desktopSet) {
+        //! No autostart mechanism exists yet; create the XDG entry.
+        Layouts::Importer::enableAutostart();
+    }
+    //! Exactly one mechanism is active; nothing to do.
+}
+
+bool UniversalSettings::isSystemdAutostartEnabled() const
+{
+    //! Only manually/distro-installed units are considered. The
+    //! xdg-autostart-generator produced app-...@autostart.service is derived
+    //! from the XDG entry and therefore must not be counted here, otherwise
+    //! a lone XDG entry would be misreported as a conflict.
+    const QStringList unitNames{QStringLiteral("latte-dock-ng.service"), QStringLiteral("latte-dock.service")};
+
+    for (const QString &unit : unitNames) {
+        QProcess process;
+        process.start(QStringLiteral("systemctl"),
+                      {QStringLiteral("--user"), QStringLiteral("is-enabled"), QStringLiteral("--quiet"), unit});
+
+        if (!process.waitForStarted(2000)) {
+            //! systemctl unavailable; assume there is no systemd-managed autostart.
+            return false;
+        }
+
+        if (!process.waitForFinished(2000)) {
+            continue;
+        }
+
+        if (process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 bool UniversalSettings::badges3DStyle() const

--- a/app/settings/universalsettings.h
+++ b/app/settings/universalsettings.h
@@ -43,7 +43,7 @@ typedef QPair<float, float> ScreenScales;
 class UniversalSettings : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(bool autostart READ autostart WRITE setAutostart NOTIFY autostartChanged)
+    Q_PROPERTY(bool ensureAutostart READ ensureAutostart WRITE setEnsureAutostart NOTIFY autostartChanged)
     Q_PROPERTY(bool badges3DStyle READ badges3DStyle WRITE setBadges3DStyle NOTIFY badges3DStyleChanged)
     Q_PROPERTY(bool inAdvancedModeForEditSettings READ inAdvancedModeForEditSettings WRITE setInAdvancedModeForEditSettings NOTIFY inAdvancedModeForEditSettingsChanged)
     Q_PROPERTY(bool colorsScriptIsPresent READ colorsScriptIsPresent NOTIFY colorsScriptIsPresentChanged)
@@ -68,6 +68,10 @@ public:
 
     bool autostart() const;
     void setAutostart(bool state);
+
+    bool ensureAutostart() const;
+    void setEnsureAutostart(bool enabled);
+    bool autostartMechanismsConflict() const;
 
     bool badges3DStyle() const;
     void setBadges3DStyle(bool enable);
@@ -154,8 +158,12 @@ private Q_SLOTS:
     void trackedFileChanged(const QString &file);
 
     void upgrade_v010();
+
 private:
     void cleanupSettings();
+
+    void ensureAutostartEntry();
+    bool isSystemdAutostartEnabled() const;
 
     void setColorsScriptIsPresent(bool present);
 

--- a/autotests/dataunittest.cpp
+++ b/autotests/dataunittest.cpp
@@ -521,7 +521,7 @@ void DataUnitTest::preferencesDefaultsRoundTrip()
 
 void DataUnitTest::preferencesAutostartDefaultsToEnabled()
 {
-    // The Preferences page checkbox "Enable autostart during startup" must
+    // The Preferences page checkbox "Ensure autostart during startup" must
     // default to checked: both the class constant and a freshly constructed
     // Preferences object have autostart enabled.
     QVERIFY(Preferences::AUTOSTART);

--- a/autotests/importerlogictest.cpp
+++ b/autotests/importerlogictest.cpp
@@ -4,6 +4,7 @@
 */
 
 #include <KConfigGroup>
+#include <KDesktopFile>
 #include <KSharedConfig>
 
 #include <QDir>
@@ -74,7 +75,16 @@ QString deprecatedAutostartFilePath(const QString &configDir)
 
 bool isAutostartEnabled(const QString &configDir)
 {
-    return QFile::exists(autostartFilePath(configDir));
+    const QString path = autostartFilePath(configDir);
+
+    if (!QFile::exists(path)) {
+        return false;
+    }
+
+    //! Mirror Importer::isAutostartEnabled(): an entry with Hidden=true exists
+    //! on disk but is disabled per the XDG autostart spec.
+    KDesktopFile desktopFile(path);
+    return !desktopFile.desktopGroup().readEntry(QStringLiteral("Hidden"), false);
 }
 
 void enableAutostart(const QString &configDir, const QString &sourceDesktopFile)
@@ -97,7 +107,13 @@ void enableAutostart(const QString &configDir, const QString &sourceDesktopFile)
             QFileInfo autostartInfo(autostartFile);
             QFileInfo sourceInfo(sourceDesktopFile);
 
-            if (autostartInfo.lastModified() >= sourceInfo.lastModified()) {
+            //! Mirror Importer::enableAutostart(): a present-but-hidden entry
+            //! must be re-enabled (Hidden cleared) even when it is newer than
+            //! the source.
+            KDesktopFile existing(autostartFile);
+            const bool hidden = existing.desktopGroup().readEntry(QStringLiteral("Hidden"), false);
+
+            if (!hidden && autostartInfo.lastModified() >= sourceInfo.lastModified()) {
                 return; // up to date
             }
 
@@ -154,6 +170,8 @@ private Q_SLOTS:
     // Autostart management tests
     void autostartNotEnabledWhenFileMissing();
     void autostartEnabledWhenFileExists();
+    void autostartDisabledWhenHiddenTrue();
+    void enableReenablesHiddenEntry();
     void enableCreatesAutostartFile();
     void enableWithEmptySourceDoesNothing();
     void disableRemovesAutostartFile();
@@ -240,6 +258,49 @@ void ImporterLogicTest::autostartEnabledWhenFileExists()
     f.write("[Desktop Entry]\n");
     f.close();
 
+    QVERIFY(ImporterLogic::isAutostartEnabled(configDir.path()));
+}
+
+void ImporterLogicTest::autostartDisabledWhenHiddenTrue()
+{
+    //! A present-but-hidden XDG entry must be reported as disabled.
+    QTemporaryDir configDir;
+    const QString autostartDir = configDir.path() + QStringLiteral("/autostart");
+    QDir().mkpath(autostartDir);
+
+    QFile f(ImporterLogic::autostartFilePath(configDir.path()));
+    QVERIFY(f.open(QFile::WriteOnly));
+    f.write("[Desktop Entry]\nHidden=true\n");
+    f.close();
+
+    QVERIFY(!ImporterLogic::isAutostartEnabled(configDir.path()));
+}
+
+void ImporterLogicTest::enableReenablesHiddenEntry()
+{
+    //! enableAutostart() must clear Hidden=true even when the disabled entry
+    //! is newer than the source, otherwise a hidden entry could never be
+    //! re-enabled through the ensure-autostart path.
+    QTemporaryDir configDir;
+    QTemporaryDir sourceDir;
+
+    const QString sourcePath = sourceDir.path() + QStringLiteral("/org.kde.latte-dock.desktop");
+    QFile source(sourcePath);
+    QVERIFY(source.open(QFile::WriteOnly));
+    source.write("[Desktop Entry]\nExec=/usr/bin/latte-dock-ng\n");
+    source.close();
+
+    const QString autostartDir = configDir.path() + QStringLiteral("/autostart");
+    QDir().mkpath(autostartDir);
+
+    QFile entry(ImporterLogic::autostartFilePath(configDir.path()));
+    QVERIFY(entry.open(QFile::WriteOnly));
+    entry.write("[Desktop Entry]\nHidden=true\n");
+    entry.close();
+
+    QVERIFY(!ImporterLogic::isAutostartEnabled(configDir.path()));
+
+    ImporterLogic::enableAutostart(configDir.path(), sourcePath);
     QVERIFY(ImporterLogic::isAutostartEnabled(configDir.path()));
 }
 

--- a/autotests/sourcecontracttest.cpp
+++ b/autotests/sourcecontracttest.cpp
@@ -58,7 +58,7 @@ private Q_SLOTS:
     void autostartDefaultEnabledContracts();
     void desktopFileHasAutostartPhaseKey();
     void enableAutostartExitsImmediately();
-    void universalSettingsSelfHealsMissingAutostart();
+    void universalSettingsEnsureAutostartEntryHandlesBothMechanisms();
     void enableAutostartStagesUpdateAndWarns();
     void waylandCheckHasRetryMechanism();
     void enableAutostartUpdatesOutdatedFile();
@@ -1572,8 +1572,8 @@ void SourceContractTest::cmakePackagingConfigLivesInModule()
 
 void SourceContractTest::autostartDefaultEnabledContracts()
 {
-    //! "Enable autostart during startup" (Preferences page) must default to
-    //! enabled and the first-run logic must create the autostart entry once.
+    //! "Ensure autostart during startup" (Preferences page) must default to
+    //! checked, and startup must ensure at least one autostart mechanism exists.
 
     QFile preferencesHeader(QStringLiteral(LATTE_SOURCE_DIR "/app/data/preferencesdata.h"));
     QVERIFY(preferencesHeader.open(QFile::ReadOnly));
@@ -1585,19 +1585,14 @@ void SourceContractTest::autostartDefaultEnabledContracts()
     QVERIFY(universalSettings.open(QFile::ReadOnly));
     const QString universalSource = QString::fromUtf8(universalSettings.readAll());
 
-    //! First-run chain: when the user never configured autostart and it is
-    //! disabled, enable it exactly once and remember the decision.
-    const int userSetRead = universalSource.indexOf(
-                                QStringLiteral("bool autostartUserSet = m_universalGroup.readEntry(QStringLiteral(\"userConfiguredAutostart\"), false);"));
-    const int firstRunGuard = universalSource.indexOf(
-                                  QStringLiteral("if (!autostartUserSet && !autostart()) {"), userSetRead);
-    const int enableCall = universalSource.indexOf(QStringLiteral("setAutostart(true);"), firstRunGuard);
-    const int rememberDecision = universalSource.indexOf(
-                                     QStringLiteral("m_universalGroup.writeEntry(QStringLiteral(\"userConfiguredAutostart\"), true);"), enableCall);
-    QVERIFY(userSetRead >= 0);
-    QVERIFY(firstRunGuard > userSetRead);
-    QVERIFY(enableCall > firstRunGuard);
-    QVERIFY(rememberDecision > enableCall);
+    //! ensureAutostart() defaults to enabled.
+    QVERIFY(universalSource.contains(QStringLiteral("readEntry(QStringLiteral(\"ensureAutostart\"), true)")));
+
+    //! Startup only acts when ensure-autostart is enabled.
+    const int loadGuard = universalSource.indexOf(QStringLiteral("if (ensureAutostart()) {"));
+    const int ensureCall = universalSource.indexOf(QStringLiteral("ensureAutostartEntry();"), loadGuard);
+    QVERIFY(loadGuard >= 0);
+    QVERIFY(ensureCall > loadGuard);
 
     //! Autostart state is the existence of the desktop file, and enabling
     //! copies the installed application launcher.
@@ -1638,24 +1633,30 @@ void SourceContractTest::enableAutostartExitsImmediately()
     QVERIFY(returnZero > exitCall);
 }
 
-void SourceContractTest::universalSettingsSelfHealsMissingAutostart()
+void SourceContractTest::universalSettingsEnsureAutostartEntryHandlesBothMechanisms()
 {
-    //! Once the user has configured autostart (userConfiguredAutostart=true),
-    //! the first-run creation path never runs again.  If the desktop file
-    //! disappears later (uninstall, failed update), startup must restore it
-    //! instead of silently breaking autostart on every login.
+    //! ensureAutostartEntry() must implement the flagA/flagB decision table:
+    //! create the XDG entry only when neither mechanism is present, and only
+    //! log when both are present. Disabling must stay silent and never touch
+    //! existing entries.
     QFile universalSettings(QStringLiteral(LATTE_SOURCE_DIR "/app/settings/universalsettings.cpp"));
     QVERIFY(universalSettings.open(QFile::ReadOnly));
-    const QString universalSource = QString::fromUtf8(universalSettings.readAll());
+    const QString source = QString::fromUtf8(universalSettings.readAll());
 
-    const int rememberDecision = universalSource.indexOf(
-                                     QStringLiteral("m_universalGroup.writeEntry(QStringLiteral(\"userConfiguredAutostart\"), true);"));
-    QVERIFY(rememberDecision >= 0);
+    QVERIFY(source.contains(QStringLiteral("const bool systemdSet = isSystemdAutostartEnabled();")));
+    QVERIFY(source.contains(QStringLiteral("const bool desktopSet = Layouts::Importer::isAutostartEnabled();")));
+    QVERIFY(source.contains(QStringLiteral("} else if (!systemdSet && !desktopSet) {")));
+    QVERIFY(source.contains(QStringLiteral("Layouts::Importer::enableAutostart();")));
 
-    //! Self-heal call must come after the first-run decision is remembered,
-    //! so the recreate path is the one for a configured-but-missing entry.
-    const int selfHealCall = universalSource.indexOf(QStringLiteral("setAutostart(true);"), rememberDecision);
-    QVERIFY(selfHealCall > rememberDecision);
+    //! The systemd check must only look at manually/distro-installed units,
+    //! never the xdg-autostart-generator produced app-...@autostart.service.
+    QVERIFY(source.contains(QStringLiteral("latte-dock-ng.service")));
+    QVERIFY(source.contains(QStringLiteral("latte-dock.service")));
+
+    //! setEnsureAutostart(false) must be silent and not remove anything.
+    const int setEnsure = source.indexOf(QStringLiteral("void UniversalSettings::setEnsureAutostart(bool enabled)"));
+    QVERIFY(setEnsure >= 0);
+    QVERIFY(source.indexOf(QStringLiteral("writeEntry(QStringLiteral(\"ensureAutostart\"), enabled)"), setEnsure) > setEnsure);
 }
 
 void SourceContractTest::enableAutostartStagesUpdateAndWarns()


### PR DESCRIPTION
Replace the forced XDG autostart behavior with an opt-out, mechanism-aware ensure policy.

The previous logic force-enabled the XDG entry on every startup and could never be turned off: userConfiguredAutostart was only ever written true, and a self-heal branch recreated a deleted desktop file. On Plasma 6 both the XDG entry and a systemd user unit can start Latte, so the GUI checkbox needs a single coherent meaning for both.

Rework the Preferences checkbox into "Ensure autostart during startup":

- Add ensureAutostart, enabled by default. When enabled, create the XDG entry only if neither an enabled Latte systemd user unit nor an active XDG entry exists. Warn when both mechanisms are enabled and otherwise leave the existing mechanism untouched.
- load() stays silent and touches nothing when the checkbox is unchecked.
- Detect only latte-dock-ng.service and latte-dock.service as independent systemd mechanisms, excluding the unit generated from the XDG entry.
- Honor Hidden=true when checking XDG autostart state, and replace hidden entries when explicitly re-enabling autostart.
- Persist and immediately sync explicit enable/disable decisions from the command line, Preferences dialog, and DBus setAutostart method. Disabling removes Latte's XDG entry without modifying user-managed systemd units.
- Show an inline warning in the Preferences dialog when both startup mechanisms are active.

Add source-contract coverage for the ensure decision table, plus dynamic importer tests for Hidden=true detection and re-enabling.