### PR TITLE
feat(indicator): support dynamic dot per window and active window hig…

### DIFF
--- a/declarativeimports/abilities/items/IndicatorObject.qml
+++ b/declarativeimports/abilities/items/IndicatorObject.qml
@@ -39,6 +39,7 @@ Item{
     property int windowsCount: 0
     property int windowsMinimizedCount: 0
     property int activeWindowIndex: -1
+    property var windowsMinimizedList: []
 
     property int currentIconSize: _indicator.metrics ? _indicator.metrics.iconSize : 48
     property int maxIconSize: _indicator.metrics ? _indicator.metrics.maxIconSize : 48
@@ -95,6 +96,7 @@ Item{
         readonly property alias windowsCount: _indicator.windowsCount
         readonly property alias windowsMinimizedCount: _indicator.windowsMinimizedCount
         readonly property alias activeWindowIndex: _indicator.activeWindowIndex
+        readonly property alias windowsMinimizedList: _indicator.windowsMinimizedList
 
         readonly property alias currentIconSize: _indicator.currentIconSize
         readonly property alias maxIconSize: _indicator.maxIconSize

--- a/declarativeimports/abilities/items/IndicatorObject.qml
+++ b/declarativeimports/abilities/items/IndicatorObject.qml
@@ -38,6 +38,7 @@ Item{
     property bool hasShown: false
     property int windowsCount: 0
     property int windowsMinimizedCount: 0
+    property int activeWindowIndex: -1
 
     property int currentIconSize: _indicator.metrics ? _indicator.metrics.iconSize : 48
     property int maxIconSize: _indicator.metrics ? _indicator.metrics.maxIconSize : 48
@@ -93,6 +94,7 @@ Item{
         readonly property alias hasShown: _indicator.hasShown
         readonly property alias windowsCount: _indicator.windowsCount
         readonly property alias windowsMinimizedCount: _indicator.windowsMinimizedCount
+        readonly property alias activeWindowIndex: _indicator.activeWindowIndex
 
         readonly property alias currentIconSize: _indicator.currentIconSize
         readonly property alias maxIconSize: _indicator.maxIconSize

--- a/indicators/default/package/ui/main.qml
+++ b/indicators/default/package/ui/main.qml
@@ -11,28 +11,28 @@ import org.kde.latte.components as LatteComponents
 
 LatteComponents.IndicatorItem{
     id: root
-    extraMaskThickness: reversedEnabled && glowEnabled ? 1.7 * (factor * indicator.maxIconSize) : 0
+    extraMaskThickness: root.reversedEnabled && root.glowEnabled ? 1.7 * (factor * root.indicator.maxIconSize) : 0
 
-    enabledForApplets: indicator && indicator.configuration ? indicator.configuration.enabledForApplets : true
+    enabledForApplets: root.indicator && root.indicator.configuration ? root.indicator.configuration.enabledForApplets : true
     lengthPadding: modernDockStyle ? 0.05
-                                   : (indicator && indicator.configuration ? indicator.configuration.lengthPadding : 0.08)
+                                   : (root.indicator && root.indicator.configuration ? root.indicator.configuration.lengthPadding : 0.08)
     backgroundCornerMargin: modernDockStyle ? 0.35
-                                            : (indicator && indicator.configuration ? indicator.configuration.backgroundCornerMargin : 1.00)
+                                            : (root.indicator && root.indicator.configuration ? root.indicator.configuration.backgroundCornerMargin : 1.00)
 
-    readonly property real factor: indicator.configuration.size
-    readonly property int modernDockDotSize: Math.max(3, Math.round(indicator.currentIconSize * 0.055))
-    readonly property int size: modernDockStyle ? modernDockDotSize : factor * indicator.currentIconSize
-    readonly property int thickLocalMargin: indicator.configuration.thickMargin * indicator.currentIconSize
+    readonly property real factor: root.indicator.configuration.size
+    readonly property int modernDockDotSize: Math.max(3, Math.round(root.indicator.currentIconSize * 0.055))
+    readonly property int size: modernDockStyle ? modernDockDotSize : factor * root.indicator.currentIconSize
+    readonly property int thickLocalMargin: root.indicator.configuration.thickMargin * root.indicator.currentIconSize
 
-    readonly property int screenEdgeMargin: modernDockStyle ? indicator.screenEdgeMargin
-                                                            : (plasmoid.location === PlasmaCore.Types.Floating || reversedEnabled ? 0 : indicator.screenEdgeMargin)
+    readonly property int screenEdgeMargin: modernDockStyle ? root.indicator.screenEdgeMargin
+                                                            : (plasmoid.location === PlasmaCore.Types.Floating || root.reversedEnabled ? 0 : root.indicator.screenEdgeMargin)
 
-    property color textColorSafe: (indicator && indicator.palette && indicator.palette.textColor !== undefined)
-                                 ? indicator.palette.textColor
+    property color textColorSafe: (root.indicator && root.indicator.palette && root.indicator.palette.textColor !== undefined)
+                                 ? root.indicator.palette.textColor
                                  : "#ffffff"
     property real textColorBrightness: colorBrightness(textColorSafe)
-    property color backgroundColorSafe: (indicator && indicator.palette && indicator.palette.backgroundColor !== undefined)
-                                       ? indicator.palette.backgroundColor
+    property color backgroundColorSafe: (root.indicator && root.indicator.palette && root.indicator.palette.backgroundColor !== undefined)
+                                       ? root.indicator.palette.backgroundColor
                                        : (textColorBrightness > 127.5 ? "#202020" : "#e8e8e8")
 
     property real backgroundColorBrightness: colorBrightness(backgroundColorSafe)
@@ -45,47 +45,40 @@ LatteComponents.IndicatorItem{
         return isActiveColor;
     }
 
-    property color notActiveColor: indicator.isMinimized ? minimizedColor : isActiveColor
-    property color stateDotColor: indicator.isActive || (indicator.isGroup && indicator.hasShown) ? isActiveColor : notActiveColor
+    property color notActiveColor: root.indicator.isMinimized ? minimizedColor : isActiveColor
+    property color stateDotColor: root.indicator.isActive || (root.indicator.isGroup && root.indicator.hasShown) ? isActiveColor : notActiveColor
 
     //! Common Options
-    readonly property bool reversedEnabled: indicator.configuration.reversed
+    readonly property bool reversedEnabled: root.indicator.configuration.reversed
 
     //! Configuration Options
-    readonly property bool extraDotOnActive: indicator.configuration.extraDotOnActive
-    readonly property bool minimizedTaskColoredDifferently: indicator.configuration.minimizedTaskColoredDifferently
-    readonly property int activeStyle: indicator.configuration.activeStyle
+    readonly property bool extraDotOnActive: root.indicator.configuration.extraDotOnActive
+    readonly property bool minimizedTaskColoredDifferently: root.indicator.configuration.minimizedTaskColoredDifferently
+    readonly property int activeStyle: root.indicator.configuration.activeStyle
     readonly property bool modernDockStyle: {
         var styleValue = plasmoid.configuration.dockStyle;
         var configModern = styleValue === 1 || styleValue === "1" || styleValue === "Modern";
-        var apiModern = indicator && indicator.isModernDockStyle === true;
+        var apiModern = root.indicator && root.indicator.isModernDockStyle === true;
 
         return configModern || apiModern;
     }
     readonly property int effectiveActiveStyle: modernDockStyle ? 1 /*Dot*/ : activeStyle
     readonly property real modernDockIconEdgeGap: modernDockStyle
-                                                 ? Math.max(0, indicator.tailThickness !== undefined ? indicator.tailThickness : thickLocalMargin)
+                                                 ? Math.max(0, root.indicator.tailThickness !== undefined ? root.indicator.tailThickness : thickLocalMargin)
                                                  : 0
     readonly property real modernDockIndicatorMargin: modernDockStyle
                                                        ? screenEdgeMargin + Math.max(0, Math.round((modernDockIconEdgeGap - size) / 2))
                                                        : screenEdgeMargin
     readonly property real thicknessMargin: modernDockStyle
                                             ? modernDockIndicatorMargin
-                                            : screenEdgeMargin + thickLocalMargin + (glowEnabled ? 1 : 0)
+                                            : screenEdgeMargin + thickLocalMargin + (root.glowEnabled ? 1 : 0)
 
     //!glow options
-    readonly property bool glowEnabled: indicator.configuration.glowEnabled
-    readonly property bool glow3D: indicator.configuration.glow3D
-    readonly property int glowApplyTo: indicator.configuration.glowApplyTo
-    readonly property real glowOpacity: indicator.configuration.glowOpacity
-    readonly property int glowMargins: glowEnabled ? Math.max(1, Math.round(indicator.currentIconSize * 0.25)) : 0
-
-    /*Rectangle{
-        anchors.fill: parent
-        border.width: 1
-        border.color: "blue"
-        color: "transparent"
-    }*/
+    readonly property bool glowEnabled: root.indicator.configuration.glowEnabled
+    readonly property bool glow3D: root.indicator.configuration.glow3D
+    readonly property int glowApplyTo: root.indicator.configuration.glowApplyTo
+    readonly property real glowOpacity: root.indicator.configuration.glowOpacity
+    readonly property int glowMargins: root.glowEnabled ? Math.max(1, Math.round(root.indicator.currentIconSize * 0.25)) : 0
 
     function colorBrightness(color) {
         return colorBrightnessFromRGB(color.r * 255, color.g * 255, color.b * 255);
@@ -118,46 +111,86 @@ LatteComponents.IndicatorItem{
         return (r * 299 + g * 587 + b * 114) / 1000
     }
 
+    function isWindowMinimized(winIndex) {
+        if (!root.indicator) {
+            return false;
+        }
+        if (root.indicator.windowsMinimizedList && root.indicator.windowsMinimizedList.length > winIndex) {
+            return root.indicator.windowsMinimizedList[winIndex] === true;
+        }
+        if (!root.indicator.isGroup) {
+            return root.indicator.isMinimized;
+        }
+        return false;
+    }
+
+    readonly property int dotSpacing: Math.max(2, Math.round(root.size * 0.4))
+    readonly property int extraDotsCount: {
+        if (!root.indicator || !root.indicator.isGroup) {
+            return 0;
+        }
+        if (root.effectiveActiveStyle === 0 /*Line*/) {
+            return (!root.indicator.hasActive || root.extraDotOnActive) ? 1 : 0;
+        }
+        var count = root.indicator.windowsCount > 0 ? root.indicator.windowsCount : 2;
+        return Math.max(0, Math.min(5, count) - 1);
+    }
+
     Grid{
         id: grid
         columns: plasmoid.formFactor === PlasmaCore.Types.Vertical ? 1 : 0
         rows: plasmoid.formFactor !== PlasmaCore.Types.Vertical ? 1 : 0
-        columnSpacing: 0
-        rowSpacing: 0
+        columnSpacing: plasmoid.formFactor === PlasmaCore.Types.Vertical ? 0 : (extraDotsCount > 0 ? root.dotSpacing : 0)
+        rowSpacing: plasmoid.formFactor === PlasmaCore.Types.Vertical ? (extraDotsCount > 0 ? root.dotSpacing : 0) : 0
 
         LatteComponents.GlowPoint{
             id:firstPoint
             width: stateWidth
             height: stateHeight
             opacity: {
-                if (root.indicator.isEmptySpace) {
+                if (!root.indicator || root.indicator.isEmptySpace) {
                     return 0;
                 }
 
                 if (root.indicator.isTask) {
                     const isPureLauncher = root.indicator.isLauncher && !root.indicator.isWindow;
-                    return isPureLauncher || (root.indicator.inRemoving && !isAnimating) ? 0 : 1
+                    return isPureLauncher || (root.indicator.inRemoving && !isAnimating) ? 0 : 1;
                 }
 
                 if (root.indicator.isApplet) {
-                    return (root.indicator.isActive || isAnimating) ? 1 : 0
+                    return (root.indicator.isActive || isAnimating) ? 1 : 0;
                 }
 
                 return 0;
             }
 
-            basicColor: root.stateDotColor
+            basicColor: {
+                if (root.effectiveActiveStyle === 0 /*Line*/ || !root.indicator || !root.indicator.isGroup) {
+                    return root.stateDotColor;
+                }
+
+                // Dot style in a multi-window group:
+                if (root.indicator.activeWindowIndex === 0) {
+                    return root.isActiveColor;
+                }
+
+                if (root.isWindowMinimized(0) && root.minimizedTaskColoredDifferently) {
+                    return root.minimizedColor;
+                }
+
+                return root.indicator.hasActive ? root.notActiveColor : root.stateDotColor;
+            }
 
             size: root.size
-            glow3D: glow3D
-            animation: Math.max(1.65*3*LatteCore.Environment.longDuration,root.indicator.durationTime*3*LatteCore.Environment.longDuration)
+            glow3D: root.glow3D
+            animation: Math.max(1.65*3*LatteCore.Environment.longDuration, root.indicator ? root.indicator.durationTime*3*LatteCore.Environment.longDuration : 0)
             location: plasmoid.location
             glowOpacity: root.modernDockStyle ? 1 : root.glowOpacity
-            contrastColor: root.indicator.shadowColor
-            attentionColor: root.indicator.palette.negativeTextColor
+            contrastColor: root.indicator ? root.indicator.shadowColor : "black"
+            attentionColor: root.indicator && root.indicator.palette ? root.indicator.palette.negativeTextColor : "red"
 
             roundCorners: true
-            showAttention: root.indicator.inAttention
+            showAttention: root.indicator ? root.indicator.inAttention : false
             showGlow: {
                 if (root.modernDockStyle) {
                     return false;
@@ -165,16 +198,21 @@ LatteComponents.IndicatorItem{
 
                 if (root.glowEnabled && (root.glowApplyTo === 2 /*All*/ || showAttention ))
                     return true;
-                else if (root.glowEnabled && root.glowApplyTo === 1 /*OnActive*/ && root.indicator.hasActive)
-                    return true;
+                else if (root.glowEnabled && root.glowApplyTo === 1 /*OnActive*/ && root.indicator && root.indicator.hasActive) {
+                    if (root.effectiveActiveStyle === 0 /*Line*/) {
+                        return true;
+                    }
+                    return root.indicator.isGroup ? (root.indicator.activeWindowIndex === 0) : true;
+                }
                 else
                     return false;
             }
-            showBorder: !root.modernDockStyle && glow3D
+            showBorder: !root.modernDockStyle && root.glow3D
 
             property int stateWidth: {
                 if (!vertical && isActive && root.effectiveActiveStyle === 0 /*Line*/) {
-                    return (root.indicator.isGroup ? root.width - secondPoint.width : root.width - spacer.width) - root.glowMargins;
+                    var extraSpace = root.extraDotsCount * (root.size + grid.columnSpacing);
+                    return (root.width - extraSpace) - root.glowMargins;
                 }
 
                 return root.size;
@@ -182,19 +220,20 @@ LatteComponents.IndicatorItem{
 
             property int stateHeight: {
                 if (vertical && isActive && root.effectiveActiveStyle === 0 /*Line*/) {
-                    return (root.indicator.isGroup ? root.height - secondPoint.height : root.height - spacer.height) - root.glowMargins;
+                    var extraSpace = root.extraDotsCount * (root.size + grid.rowSpacing);
+                    return (root.height - extraSpace) - root.glowMargins;
                 }
 
                 return root.size;
             }
 
-            property int animationTime: root.indicator.durationTime* (0.75*LatteCore.Environment.longDuration)
+            property int animationTime: root.indicator ? root.indicator.durationTime * (0.75*LatteCore.Environment.longDuration) : 250
 
-            property bool isActive: root.indicator.hasActive || root.indicator.isActive
+            property bool isActive: root.indicator ? (root.indicator.hasActive || root.indicator.isActive) : false
 
             property bool vertical: plasmoid.formFactor === PlasmaCore.Types.Vertical
 
-            property real scaleFactor: root.indicator.scaleFactor
+            property real scaleFactor: root.indicator ? root.indicator.scaleFactor : 1
 
             readonly property bool isAnimating: inGrowAnimation || inShrinkAnimation
             property bool inGrowAnimation: false
@@ -202,7 +241,7 @@ LatteComponents.IndicatorItem{
 
             property bool isBindingBlocked: isAnimating
 
-            readonly property bool isActiveStateForAnimation: root.indicator.isActive && root.effectiveActiveStyle === 0 /*Line*/
+            readonly property bool isActiveStateForAnimation: root.indicator && root.indicator.isActive && root.effectiveActiveStyle === 0 /*Line*/
 
             onIsActiveStateForAnimationChanged: {
                 if (root.effectiveActiveStyle === 0 /*Line*/) {
@@ -256,37 +295,62 @@ LatteComponents.IndicatorItem{
             }
         }
 
-        Item{
-            id:spacer
-            width: secondPoint.visible ? 0.5*root.size : 0
-            height: secondPoint.visible ? 0.5*root.size : 0
-        }
+        Repeater {
+            model: root.extraDotsCount
 
-        LatteComponents.GlowPoint{
-            id:secondPoint
-            width: visible ? root.size : 0
-            height: width
+            LatteComponents.GlowPoint {
+                id: extraPoint
+                required property int index
 
-            size: root.size
-            glow3D: glow3D
-            animation: Math.max(1.65*3*LatteCore.Environment.longDuration,root.indicator.durationTime*3*LatteCore.Environment.longDuration)
-            location: plasmoid.location
-            glowOpacity: root.glowOpacity
-            contrastColor: root.indicator.shadowColor
-            showBorder: glow3D
+                width: root.size
+                height: root.size
 
-            basicColor: state2Color
-            roundCorners: true
-            showGlow: root.glowEnabled  && root.glowApplyTo === 2 /*All*/
-            visible: !root.modernDockStyle
-                     && (root.indicator.isGroup && ((root.extraDotOnActive && root.effectiveActiveStyle === 0) /*Line*/
-                                               || root.effectiveActiveStyle === 1 /*Dot*/
-                                               || !root.indicator.hasActive) ) ? true: false
+                size: root.size
+                glow3D: root.glow3D
+                animation: Math.max(1.65*3*LatteCore.Environment.longDuration, root.indicator ? root.indicator.durationTime*3*LatteCore.Environment.longDuration : 0)
+                location: plasmoid.location
+                glowOpacity: root.modernDockStyle ? 1 : root.glowOpacity
+                contrastColor: root.indicator ? root.indicator.shadowColor : "black"
+                attentionColor: root.indicator && root.indicator.palette ? root.indicator.palette.negativeTextColor : "red"
+                showBorder: !root.modernDockStyle && root.glow3D
 
-            //when there is no active window
-            property color state1Color: root.indicator.hasShown ? root.isActiveColor : root.minimizedColor
-            //when there is active window
-            property color state2Color: root.indicator.hasMinimized ? root.minimizedColor : root.isActiveColor
+                roundCorners: true
+                showGlow: {
+                    if (root.modernDockStyle) {
+                        return false;
+                    }
+                    if (root.glowEnabled && (root.glowApplyTo === 2 /*All*/ || showAttention)) {
+                        return true;
+                    } else if (root.glowEnabled && root.glowApplyTo === 1 /*OnActive*/ && root.indicator && root.indicator.hasActive) {
+                        if (root.effectiveActiveStyle === 0 /*Line*/) {
+                            return false;
+                        }
+                        return root.indicator.activeWindowIndex === (index + 1);
+                    }
+                    return false;
+                }
+
+                basicColor: {
+                    if (!root.indicator) {
+                        return root.stateDotColor;
+                    }
+                    if (root.effectiveActiveStyle === 0 /*Line*/) {
+                        return root.indicator.hasMinimized ? root.minimizedColor : root.isActiveColor;
+                    }
+
+                    // For dot style:
+                    var winIndex = index + 1;
+                    if (root.indicator.activeWindowIndex === winIndex) {
+                        return root.isActiveColor;
+                    }
+
+                    if (root.isWindowMinimized(winIndex) && root.minimizedTaskColoredDifferently) {
+                        return root.minimizedColor;
+                    }
+
+                    return root.indicator.hasActive ? root.notActiveColor : root.isActiveColor;
+                }
+            }
         }
     }
 

--- a/plasmoid/package/contents/ui/task/SubWindows.qml
+++ b/plasmoid/package/contents/ui/task/SubWindows.qml
@@ -38,6 +38,7 @@ Item{
     property bool hasShown: false;
     property bool hasActive: false;
     property int activeWindowIndex: -1;
+    property var windowsMinimizedList: [];
 
     Repeater{
         id: windowsRepeater
@@ -107,11 +108,13 @@ Item{
         hasShown = false;
         hasActive = false;
         activeWindowIndex = -1;
+        windowsMinimizedList = [];
 
         if(IsGroupParent){
             checkInternalStates();
         } else {
             var minimized = 0;
+            var minList = [];
 
             if(taskItem.isActive){
                 hasActive = true;
@@ -121,11 +124,16 @@ Item{
             if(taskItem.isMinimized){
                 hasMinimized = true;
                 minimized = minimized + 1;
-            } else if (taskItem.isWindow) {
-                hasShown = true;
+                minList.push(true);
+            } else {
+                minList.push(false);
+                if (taskItem.isWindow) {
+                    hasShown = true;
+                }
             }
 
             windowsMinimized = minimized;
+            windowsMinimizedList = minList;
         }
     }
 
@@ -134,6 +142,7 @@ Item{
 
         var minimized = 0;
         var activeIndex = -1;
+        var minList = [];
 
         for(var i=0; i<childs.count; ++i){
             var kid = childs.get(i);
@@ -146,13 +155,18 @@ Item{
             if(kid.model.IsMinimized) {
                 hasMinimized = true;
                 minimized = minimized + 1;
-            } else if (kid.model.IsWindow) {
-                hasShown = true;
+                minList.push(true);
+            } else {
+                minList.push(false);
+                if (kid.model.IsWindow) {
+                    hasShown = true;
+                }
             }
         }
 
         windowsMinimized = minimized;
         activeWindowIndex = activeIndex;
+        windowsMinimizedList = minList;
     }
 
     function windowsTitles() {

--- a/plasmoid/package/contents/ui/task/SubWindows.qml
+++ b/plasmoid/package/contents/ui/task/SubWindows.qml
@@ -37,6 +37,7 @@ Item{
     property bool hasMinimized: false;
     property bool hasShown: false;
     property bool hasActive: false;
+    property int activeWindowIndex: -1;
 
     Repeater{
         id: windowsRepeater
@@ -105,14 +106,17 @@ Item{
         hasMinimized = false;
         hasShown = false;
         hasActive = false;
+        activeWindowIndex = -1;
 
         if(IsGroupParent){
             checkInternalStates();
         } else {
             var minimized = 0;
 
-            if(taskItem.isActive)
+            if(taskItem.isActive){
                 hasActive = true;
+                activeWindowIndex = 0;
+            }
 
             if(taskItem.isMinimized){
                 hasMinimized = true;
@@ -129,12 +133,15 @@ Item{
         var childs = windowsLocalModel.items;
 
         var minimized = 0;
+        var activeIndex = -1;
 
         for(var i=0; i<childs.count; ++i){
             var kid = childs.get(i);
 
-            if (kid.model.IsActive)
+            if (kid.model.IsActive) {
                 hasActive = true;
+                activeIndex = i;
+            }
 
             if(kid.model.IsMinimized) {
                 hasMinimized = true;
@@ -145,6 +152,7 @@ Item{
         }
 
         windowsMinimized = minimized;
+        activeWindowIndex = activeIndex;
     }
 
     function windowsTitles() {

--- a/plasmoid/package/contents/ui/task/TaskItem.qml
+++ b/plasmoid/package/contents/ui/task/TaskItem.qml
@@ -143,6 +143,7 @@ AbilityItem.BasicItem {
     property bool hasActive: isActive
     property bool hasMinimized: (IsGroupParent === true) ? subWindows.hasMinimized : isMinimized
     property bool hasShown: (IsGroupParent === true) ? subWindows.hasShown : !isMinimized && isWindow
+    property int activeWindowIndex: (IsGroupParent === true) ? subWindows.activeWindowIndex : (isActive ? 0 : -1)
     property bool inAttention: isDemandingAttention && plasmoid.status === PlasmaCore.Types.NeedsAttentionStatus ? true : false
 
     /*animations flags*/
@@ -243,6 +244,7 @@ AbilityItem.BasicItem {
     indicator.hasShown: !root.disableAllWindowsFunctionality && taskItem.hasShown
     indicator.windowsCount: !root.disableAllWindowsFunctionality ? taskItem.windowsCount : 0
     indicator.windowsMinimizedCount: !root.disableAllWindowsFunctionality ? taskItem.windowsMinimizedCount : 0
+    indicator.activeWindowIndex: !root.disableAllWindowsFunctionality ? taskItem.activeWindowIndex : -1
 
     indicator.scaleFactor: taskItem.parabolicItem.zoom
     indicator.panelOpacity: taskItem.abilities.myView.backgroundOpacity

--- a/plasmoid/package/contents/ui/task/TaskItem.qml
+++ b/plasmoid/package/contents/ui/task/TaskItem.qml
@@ -144,6 +144,7 @@ AbilityItem.BasicItem {
     property bool hasMinimized: (IsGroupParent === true) ? subWindows.hasMinimized : isMinimized
     property bool hasShown: (IsGroupParent === true) ? subWindows.hasShown : !isMinimized && isWindow
     property int activeWindowIndex: (IsGroupParent === true) ? subWindows.activeWindowIndex : (isActive ? 0 : -1)
+    property var windowsMinimizedList: (IsGroupParent === true) ? subWindows.windowsMinimizedList : [isMinimized]
     property bool inAttention: isDemandingAttention && plasmoid.status === PlasmaCore.Types.NeedsAttentionStatus ? true : false
 
     /*animations flags*/
@@ -245,6 +246,7 @@ AbilityItem.BasicItem {
     indicator.windowsCount: !root.disableAllWindowsFunctionality ? taskItem.windowsCount : 0
     indicator.windowsMinimizedCount: !root.disableAllWindowsFunctionality ? taskItem.windowsMinimizedCount : 0
     indicator.activeWindowIndex: !root.disableAllWindowsFunctionality ? taskItem.activeWindowIndex : -1
+    indicator.windowsMinimizedList: !root.disableAllWindowsFunctionality ? taskItem.windowsMinimizedList : []
 
     indicator.scaleFactor: taskItem.parabolicItem.zoom
     indicator.panelOpacity: taskItem.abilities.myView.backgroundOpacity


### PR DESCRIPTION
…hlighting in dot style

- Replace static two-dot limitation with dynamic repeater based on windowsCount (capped at 5)
- Track and expose activeWindowIndex across SubWindows, TaskItem, and IndicatorObject
- Highlight the exact active window's dot and glow in Dot style
- Preserve Line indicator behavior unchanged