### PR TITLE
fix(indicator): preserve default type for classic dock style

### DIFF
--- a/shell/package/contents/configuration/pages/AppearanceConfig.qml
+++ b/shell/package/contents/configuration/pages/AppearanceConfig.qml
@@ -71,8 +71,9 @@ PlasmaComponents.Page {
                 plasmoid.configuration.iconSize = 64;
             }
 
+            page.latteView.indicator.type = "org.kde.latte.default";
+
             if (targetStyle === 1) { // Modern
-                page.latteView.indicator.type = "org.kde.latte.default";
                 // Modern keeps the default indicator but changes its geometry in the indicator QML.
             } else { // Classic
                 var classicPanelSize = Number(plasmoid.configuration.panelSize);


### PR DESCRIPTION
### Problem\nPR #53 moved the default indicator type assignment into the Modern branch. Switching from Modern to Classic could therefore retain a non-default indicator type.\n\n### Fix\nRestore the assignment before the Modern/Classic branch so both dock styles use the default indicator type.\n\n### Validation\n- git diff --check\n- QML lint (233 files)